### PR TITLE
fix: use atomic file creation for prettier server install lock

### DIFF
--- a/packages/daco/lib/src/prettier.dart
+++ b/packages/daco/lib/src/prettier.dart
@@ -56,11 +56,12 @@ class PrettierService {
     // and works correctly across isolates within the same process, unlike
     // fcntl-based file locks which are per-process on Linux.
     final lockFilePath = await _lockFilePath;
+    final lockFile = File(lockFilePath);
     bool acquiredLock;
     try {
-      File(lockFilePath).createSync(exclusive: true);
+      lockFile.createSync(exclusive: true);
       acquiredLock = true;
-    } on FileSystemException {
+    } on PathExistsException {
       acquiredLock = false;
     }
 
@@ -75,11 +76,13 @@ class PrettierService {
         _logger.stdout('prettier server installed.');
       } finally {
         try {
-          File(lockFilePath).deleteSync();
+          lockFile.deleteSync();
         } on FileSystemException catch (_) {}
       }
     } else {
       // Another isolate or process is already installing. Wait for it.
+      // If the lock holder fails and removes the lock without producing the
+      // entrypoint, retry acquiring the lock ourselves.
       if (_logger.isVerbose) {
         _logger.trace('Waiting for prettier server installation...');
       }
@@ -89,6 +92,10 @@ class PrettierService {
           throw Exception(
             'Timed out waiting for prettier server installation.',
           );
+        }
+        if (!lockFile.existsSync()) {
+          // Lock holder finished without producing the entrypoint. Retry.
+          return installPrettierServer();
         }
         await Future<void>.delayed(const Duration(milliseconds: 200));
       }

--- a/packages/daco/lib/src/prettier.dart
+++ b/packages/daco/lib/src/prettier.dart
@@ -10,8 +10,8 @@ import 'logging.dart';
 import 'utils.dart';
 
 final _serverPath = packageRoot.then((dir) => p.join(dir, 'prettier-server'));
-final _lockFilePath = _serverPath.then((dir) => p.join(dir, 'lock'));
-final _nodeModulesPath = _serverPath.then((dir) => p.join(dir, 'node_modules'));
+final _lockFilePath =
+    _serverPath.then((dir) => p.join(dir, '.install-lock'));
 final _serverEntrypoint = _serverPath.then(
   (dir) => p.join(dir, 'dist/tsc-out/index.js'),
 );
@@ -45,24 +45,54 @@ class PrettierService {
 
   /// Installs the prettier server if it is not already installed.
   Future<void> installPrettierServer() async {
-    // We use a lock file to ensure that the NPM package is only installed once.
-    final lockFile = await File(await _lockFilePath).open(mode: FileMode.write);
-    await lockFile.lock(FileLock.blockingExclusive);
-
-    try {
-      if (Directory(await _nodeModulesPath).existsSync()) {
-        if (_logger.isVerbose) {
-          _logger.trace('prettier server is already installed.');
-        }
-        return;
+    final serverEntrypoint = await _serverEntrypoint;
+    if (File(serverEntrypoint).existsSync()) {
+      if (_logger.isVerbose) {
+        _logger.trace('prettier server is already installed.');
       }
+      return;
+    }
 
-      _logger.stdout('Installing prettier server...');
-      await runProcess('npm', ['ci'], workingDirectory: await _serverPath);
-      _logger.stdout('prettier server installed.');
-    } finally {
-      await lockFile.unlock();
-      await lockFile.close();
+    // Use exclusive file creation as a lock. This is atomic on all platforms
+    // and works correctly across isolates within the same process, unlike
+    // fcntl-based file locks which are per-process on Linux.
+    final lockFilePath = await _lockFilePath;
+    bool acquiredLock;
+    try {
+      File(lockFilePath).createSync(exclusive: true);
+      acquiredLock = true;
+    } on FileSystemException {
+      acquiredLock = false;
+    }
+
+    if (acquiredLock) {
+      try {
+        if (File(serverEntrypoint).existsSync()) {
+          return;
+        }
+
+        _logger.stdout('Installing prettier server...');
+        await runProcess('npm', ['ci'], workingDirectory: await _serverPath);
+        _logger.stdout('prettier server installed.');
+      } finally {
+        try {
+          File(lockFilePath).deleteSync();
+        } catch (_) {}
+      }
+    } else {
+      // Another isolate or process is already installing. Wait for it.
+      if (_logger.isVerbose) {
+        _logger.trace('Waiting for prettier server installation...');
+      }
+      final deadline = DateTime.now().add(const Duration(minutes: 2));
+      while (!File(serverEntrypoint).existsSync()) {
+        if (DateTime.now().isAfter(deadline)) {
+          throw Exception(
+            'Timed out waiting for prettier server installation.',
+          );
+        }
+        await Future.delayed(const Duration(milliseconds: 200));
+      }
     }
   }
 

--- a/packages/daco/lib/src/prettier.dart
+++ b/packages/daco/lib/src/prettier.dart
@@ -10,8 +10,7 @@ import 'logging.dart';
 import 'utils.dart';
 
 final _serverPath = packageRoot.then((dir) => p.join(dir, 'prettier-server'));
-final _lockFilePath =
-    _serverPath.then((dir) => p.join(dir, '.install-lock'));
+final _lockFilePath = _serverPath.then((dir) => p.join(dir, '.install-lock'));
 final _serverEntrypoint = _serverPath.then(
   (dir) => p.join(dir, 'dist/tsc-out/index.js'),
 );
@@ -77,7 +76,7 @@ class PrettierService {
       } finally {
         try {
           File(lockFilePath).deleteSync();
-        } catch (_) {}
+        } on FileSystemException catch (_) {}
       }
     } else {
       // Another isolate or process is already installing. Wait for it.
@@ -91,7 +90,7 @@ class PrettierService {
             'Timed out waiting for prettier server installation.',
           );
         }
-        await Future.delayed(const Duration(milliseconds: 200));
+        await Future<void>.delayed(const Duration(milliseconds: 200));
       }
     }
   }

--- a/packages/daco/prettier-server/.gitignore
+++ b/packages/daco/prettier-server/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 dist/
 
-lock
+.install-lock


### PR DESCRIPTION
On Linux, `fcntl` advisory locks (used by Dart's `RandomAccessFile.lock`) are per-process, not per-file-descriptor. When `dart test` runs test files concurrently as isolates within the same process, the lock in `installPrettierServer` doesn't prevent concurrent `npm ci` runs, which corrupt the installation and cause the prettier server to fail to start.

This replaces the locking mechanism with `File.createSync(exclusive: true)` (`O_CREAT | O_EXCL`), which is atomic on all platforms and works correctly across isolates. The "installed" check is also changed from `node_modules` existence to the built server entrypoint (`dist/tsc-out/index.js`), and a 2-minute timeout is added when waiting for a concurrent installation.