### PR TITLE
ci: add automatic publish to pub.dev workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,12 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "daco-v*"
+
+jobs:
+  publish:
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@main
+    with:
+      working-directory: packages/daco

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish to pub.dev
 
 on:
   push:
@@ -7,6 +7,8 @@ on:
 
 jobs:
   publish:
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@main
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
       working-directory: packages/daco


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically publishes the `daco` package to pub.dev when a tag matching `daco-v*` is pushed. Uses the reusable publish workflow from `dart-lang/setup-dart`, which handles OIDC authentication and dry-run checks.