### PR TITLE
feat: skip gitignored files in daco format

### DIFF
--- a/packages/daco/lib/src/commands/format.dart
+++ b/packages/daco/lib/src/commands/format.dart
@@ -54,7 +54,7 @@ class FormatCommand extends DacoCommand {
       usageException('No files specified.');
     }
 
-    final files =
+    final files = await filterGitIgnoredFiles(
         await Stream.fromIterable(
               _files.map((e) {
                 switch (FileSystemEntity.typeSync(e)) {
@@ -75,7 +75,7 @@ class FormatCommand extends DacoCommand {
                   ? Stream.value(entity)
                   : findDartFiles(entity as Directory),
             )
-            .toList();
+            .toList());
 
     final prettierService = PrettierService(logger: logger);
     await prettierService.start();

--- a/packages/daco/lib/src/commands/format.dart
+++ b/packages/daco/lib/src/commands/format.dart
@@ -55,27 +55,28 @@ class FormatCommand extends DacoCommand {
     }
 
     final files = await filterGitIgnoredFiles(
-        await Stream.fromIterable(
-              _files.map((e) {
-                switch (FileSystemEntity.typeSync(e)) {
-                  case FileSystemEntityType.file:
-                    return File(e);
-                  case FileSystemEntityType.directory:
-                    return Directory(e);
-                  case FileSystemEntityType.notFound:
-                    return usageException('File not found: $e');
-                  // ignore: no_default_cases
-                  default:
-                    unreachable();
-                }
-              }),
-            )
-            .asyncExpand(
-              (entity) => entity is File
-                  ? Stream.value(entity)
-                  : findDartFiles(entity as Directory),
-            )
-            .toList());
+      await Stream.fromIterable(
+            _files.map((e) {
+              switch (FileSystemEntity.typeSync(e)) {
+                case FileSystemEntityType.file:
+                  return File(e);
+                case FileSystemEntityType.directory:
+                  return Directory(e);
+                case FileSystemEntityType.notFound:
+                  return usageException('File not found: $e');
+                // ignore: no_default_cases
+                default:
+                  unreachable();
+              }
+            }),
+          )
+          .asyncExpand(
+            (entity) => entity is File
+                ? Stream.value(entity)
+                : findDartFiles(entity as Directory),
+          )
+          .toList(),
+    );
 
     final prettierService = PrettierService(logger: logger);
     await prettierService.start();

--- a/packages/daco/lib/src/file_utils.dart
+++ b/packages/daco/lib/src/file_utils.dart
@@ -41,14 +41,19 @@ Future<List<File>> filterGitIgnoredFiles(
 
   final ignoredPaths = stdout
       .split('\n')
+      .map((line) => line.trim())
       .where((line) => line.isNotEmpty)
-      .map<String>(p.canonicalize)
+      .map(_normalizePath)
       .toSet();
 
   return files
-      .where((file) => !ignoredPaths.contains(p.canonicalize(file.path)))
+      .where((file) => !ignoredPaths.contains(_normalizePath(file.path)))
       .toList();
 }
+
+/// Normalizes a path for cross-platform comparison by resolving `.` and `..`
+/// segments and converting all separators to forward slashes.
+String _normalizePath(String path) => p.normalize(path).replaceAll(r'\', '/');
 
 /// Whether the file at the given [path] is a Dart file.
 bool isDartFile(String path) => p.extension(path) == '.dart';

--- a/packages/daco/lib/src/file_utils.dart
+++ b/packages/daco/lib/src/file_utils.dart
@@ -8,6 +8,50 @@ Stream<File> findDartFiles(Directory directory) => directory
     .where((entry) => entry is File && isDartFile(entry.path))
     .cast<File>();
 
+/// Filters out files that are ignored by git.
+///
+/// Uses the current working directory to determine the git repository, unless
+/// [workingDirectory] is provided.
+Future<List<File>> filterGitIgnoredFiles(
+  List<File> files, {
+  String? workingDirectory,
+}) async {
+  if (files.isEmpty) {
+    return files;
+  }
+
+  final process = await Process.start(
+    'git',
+    ['check-ignore', '--stdin'],
+    workingDirectory: workingDirectory,
+  );
+
+  process.stdin.writeln(files.map((f) => f.path).join('\n'));
+  await process.stdin.close();
+
+  final stdout = await process.stdout
+      .transform(const SystemEncoding().decoder)
+      .join();
+  final exitCode = await process.exitCode;
+
+  // Exit code 1 means no files are ignored, 0 means some are.
+  // Any other code means git is not available or not in a repo.
+  if (exitCode != 0 && exitCode != 1) {
+    return files;
+  }
+
+  final ignoredPaths =
+      stdout
+          .split('\n')
+          .where((line) => line.isNotEmpty)
+          .map<String>(p.canonicalize)
+          .toSet();
+
+  return files
+      .where((file) => !ignoredPaths.contains(p.canonicalize(file.path)))
+      .toList();
+}
+
 /// Whether the file at the given [path] is a Dart file.
 bool isDartFile(String path) => p.extension(path) == '.dart';
 

--- a/packages/daco/lib/src/file_utils.dart
+++ b/packages/daco/lib/src/file_utils.dart
@@ -20,11 +20,10 @@ Future<List<File>> filterGitIgnoredFiles(
     return files;
   }
 
-  final process = await Process.start(
-    'git',
-    ['check-ignore', '--stdin'],
-    workingDirectory: workingDirectory,
-  );
+  final process = await Process.start('git', [
+    'check-ignore',
+    '--stdin',
+  ], workingDirectory: workingDirectory);
 
   process.stdin.writeln(files.map((f) => f.path).join('\n'));
   await process.stdin.close();
@@ -40,12 +39,11 @@ Future<List<File>> filterGitIgnoredFiles(
     return files;
   }
 
-  final ignoredPaths =
-      stdout
-          .split('\n')
-          .where((line) => line.isNotEmpty)
-          .map<String>(p.canonicalize)
-          .toSet();
+  final ignoredPaths = stdout
+      .split('\n')
+      .where((line) => line.isNotEmpty)
+      .map<String>(p.canonicalize)
+      .toSet();
 
   return files
       .where((file) => !ignoredPaths.contains(p.canonicalize(file.path)))

--- a/packages/daco/lib/src/file_utils.dart
+++ b/packages/daco/lib/src/file_utils.dart
@@ -25,7 +25,10 @@ Future<List<File>> filterGitIgnoredFiles(
     '--stdin',
   ], workingDirectory: workingDirectory);
 
-  process.stdin.writeln(files.map((f) => f.path).join('\n'));
+  // Use forward slashes for git compatibility on Windows.
+  process.stdin.writeln(
+    files.map((f) => f.path.replaceAll(r'\', '/')).join('\n'),
+  );
   await process.stdin.close();
 
   final stdout = await process.stdout

--- a/packages/daco/test/file_utils_test.dart
+++ b/packages/daco/test/file_utils_test.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:daco/src/file_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('daco_test_');
+  });
+
+  tearDown(() async {
+    await tempDir.delete(recursive: true);
+  });
+
+  group('filterGitIgnoredFiles', () {
+    test('filters out gitignored files', () async {
+      // Initialize a git repo in the temp directory.
+      await Process.run('git', ['init'], workingDirectory: tempDir.path);
+
+      // Create a .gitignore file.
+      final gitignore = File('${tempDir.path}/.gitignore');
+      await gitignore.writeAsString('ignored/\n');
+
+      // Create files.
+      final kept = File('${tempDir.path}/kept.dart');
+      await kept.writeAsString('');
+      final ignoredDir = Directory('${tempDir.path}/ignored');
+      await ignoredDir.create();
+      final ignored = File('${tempDir.path}/ignored/file.dart');
+      await ignored.writeAsString('');
+
+      final result = await filterGitIgnoredFiles(
+        [kept, ignored],
+        workingDirectory: tempDir.path,
+      );
+
+      expect(result.map((f) => f.path), [kept.path]);
+    });
+
+    test('returns all files when not in a git repo', () async {
+      final file = File('${tempDir.path}/test.dart');
+      await file.writeAsString('');
+
+      final result = await filterGitIgnoredFiles([file]);
+
+      expect(result.map((f) => f.path), [file.path]);
+    });
+
+    test('returns empty list for empty input', () async {
+      final result = await filterGitIgnoredFiles([]);
+
+      expect(result, isEmpty);
+    });
+  });
+}

--- a/packages/daco/test/file_utils_test.dart
+++ b/packages/daco/test/file_utils_test.dart
@@ -31,10 +31,10 @@ void main() {
       final ignored = File('${tempDir.path}/ignored/file.dart');
       await ignored.writeAsString('');
 
-      final result = await filterGitIgnoredFiles(
-        [kept, ignored],
-        workingDirectory: tempDir.path,
-      );
+      final result = await filterGitIgnoredFiles([
+        kept,
+        ignored,
+      ], workingDirectory: tempDir.path);
 
       expect(result.map((f) => f.path), [kept.path]);
     });


### PR DESCRIPTION
## Summary
- `daco format` now filters out gitignored files using `git check-ignore --stdin` before formatting
- Falls back gracefully to formatting all files when git is unavailable or not in a git repo
- Adds tests for the new `filterGitIgnoredFiles` utility