### PR TITLE
fix: Flutter symlink handling in gitignore filtering

### DIFF
--- a/packages/daco/lib/src/file_utils.dart
+++ b/packages/daco/lib/src/file_utils.dart
@@ -20,43 +20,128 @@ Future<List<File>> filterGitIgnoredFiles(
     return files;
   }
 
-  final process = await Process.start('git', [
-    'check-ignore',
-    '--stdin',
-  ], workingDirectory: workingDirectory);
-
-  // Use forward slashes for git compatibility on Windows.
-  process.stdin.writeln(
-    files.map((f) => f.path.replaceAll(r'\', '/')).join('\n'),
-  );
-  await process.stdin.close();
-
-  final stdout = await process.stdout
-      .transform(const SystemEncoding().decoder)
-      .join();
-  final exitCode = await process.exitCode;
-
-  // Exit code 1 means no files are ignored, 0 means some are.
-  // Any other code means git is not available or not in a repo.
-  if (exitCode != 0 && exitCode != 1) {
+  final repoRoot = await _gitRepoRoot(workingDirectory: workingDirectory);
+  if (repoRoot == null) {
     return files;
   }
 
-  final ignoredPaths = stdout
-      .split('\n')
-      .map((line) => line.trim())
-      .where((line) => line.isNotEmpty)
-      .map(_normalizePath)
-      .toSet();
+  final pathBase = workingDirectory ?? Directory.current.path;
+  final gitCheckPathsByFile = <File, List<String>>{};
+  final gitCheckPaths = <String>{};
+
+  for (final file in files) {
+    final filePath = _resolvePath(file.path, from: pathBase);
+    if (!_isInDirectory(filePath, repoRoot)) {
+      gitCheckPathsByFile[file] = const [];
+      continue;
+    }
+
+    final fileGitCheckPaths = _gitCheckPathsForFile(filePath, repoRoot);
+    gitCheckPathsByFile[file] = fileGitCheckPaths;
+    gitCheckPaths.addAll(fileGitCheckPaths);
+  }
+
+  final ignoredPaths = await _gitIgnoredPaths(
+    gitCheckPaths,
+    workingDirectory: repoRoot,
+  );
+  if (ignoredPaths == null) {
+    return files;
+  }
 
   return files
-      .where((file) => !ignoredPaths.contains(_normalizePath(file.path)))
+      .where(
+        (file) =>
+            !(gitCheckPathsByFile[file] ?? const []).any(ignoredPaths.contains),
+      )
       .toList();
 }
 
 /// Normalizes a path for cross-platform comparison by resolving `.` and `..`
 /// segments and converting all separators to forward slashes.
 String _normalizePath(String path) => p.normalize(path).replaceAll(r'\', '/');
+
+Future<String?> _gitRepoRoot({String? workingDirectory}) async {
+  final baseDirectory = p.normalize(workingDirectory ?? Directory.current.path);
+  final result = await Process.run('git', [
+    'rev-parse',
+    '--show-cdup',
+  ], workingDirectory: workingDirectory);
+
+  if (result.exitCode != 0) {
+    return null;
+  }
+
+  final stdout = (result.stdout as String).trim();
+  return p.normalize(p.join(baseDirectory, stdout.isEmpty ? '.' : stdout));
+}
+
+Future<Set<String>?> _gitIgnoredPaths(
+  Iterable<String> paths, {
+  required String workingDirectory,
+}) async {
+  final normalizedPaths = paths.map(_normalizePath).toSet();
+  if (normalizedPaths.isEmpty) {
+    return {};
+  }
+
+  final process = await Process.start('git', [
+    'check-ignore',
+    '--stdin',
+  ], workingDirectory: workingDirectory);
+
+  process.stdin.write('${normalizedPaths.join('\n')}\n');
+  await process.stdin.close();
+
+  final stdoutFuture = process.stdout
+      .transform(const SystemEncoding().decoder)
+      .join();
+  final stderrFuture = process.stderr.drain<void>();
+  final exitCode = await process.exitCode;
+  await stderrFuture;
+
+  // Exit code 1 means no files are ignored, 0 means some are.
+  // Any other code means git is not available or not in a repo.
+  if (exitCode != 0 && exitCode != 1) {
+    return null;
+  }
+
+  final stdout = await stdoutFuture;
+  return stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .where((line) => line.isNotEmpty)
+      .map(_normalizePath)
+      .toSet();
+}
+
+List<String> _gitCheckPathsForFile(String filePath, String repoRoot) {
+  final relativePath = p.relative(filePath, from: repoRoot);
+  final segments = p.split(relativePath);
+  final gitCheckPaths = <String>[];
+
+  var currentPath = repoRoot;
+  final currentSegments = <String>[];
+
+  for (final segment in segments) {
+    currentPath = p.join(currentPath, segment);
+    currentSegments.add(segment);
+    gitCheckPaths.add(_normalizePath(p.joinAll(currentSegments)));
+
+    if (FileSystemEntity.typeSync(currentPath, followLinks: false) ==
+        FileSystemEntityType.link) {
+      break;
+    }
+  }
+
+  return gitCheckPaths;
+}
+
+String _resolvePath(String path, {required String from}) =>
+    p.normalize(p.isAbsolute(path) ? path : p.join(from, path));
+
+bool _isInDirectory(String path, String directory) =>
+    path == directory || p.isWithin(directory, path);
 
 /// Whether the file at the given [path] is a Dart file.
 bool isDartFile(String path) => p.extension(path) == '.dart';

--- a/packages/daco/lib/src/file_utils.dart
+++ b/packages/daco/lib/src/file_utils.dart
@@ -31,11 +31,6 @@ Future<List<File>> filterGitIgnoredFiles(
 
   for (final file in files) {
     final filePath = _resolvePath(file.path, from: pathBase);
-    if (!_isInDirectory(filePath, repoRoot)) {
-      gitCheckPathsByFile[file] = const [];
-      continue;
-    }
-
     final fileGitCheckPaths = _gitCheckPathsForFile(filePath, repoRoot);
     gitCheckPathsByFile[file] = fileGitCheckPaths;
     gitCheckPaths.addAll(fileGitCheckPaths);
@@ -62,7 +57,7 @@ Future<List<File>> filterGitIgnoredFiles(
 String _normalizePath(String path) => p.normalize(path).replaceAll(r'\', '/');
 
 Future<String?> _gitRepoRoot({String? workingDirectory}) async {
-  final baseDirectory = p.normalize(workingDirectory ?? Directory.current.path);
+  final baseDirectory = p.absolute(workingDirectory ?? Directory.current.path);
   final result = await Process.run('git', [
     'rev-parse',
     '--show-cdup',
@@ -116,10 +111,13 @@ Future<Set<String>?> _gitIgnoredPaths(
 }
 
 List<String> _gitCheckPathsForFile(String filePath, String repoRoot) {
-  final relativePath = p.relative(filePath, from: repoRoot);
+  final relativePath = _relativePathFromRepoRoot(filePath, repoRoot);
+  if (relativePath == null) {
+    return const [];
+  }
+
   final segments = p.split(relativePath);
   final gitCheckPaths = <String>[];
-
   var currentPath = repoRoot;
   final currentSegments = <String>[];
 
@@ -139,6 +137,21 @@ List<String> _gitCheckPathsForFile(String filePath, String repoRoot) {
 
 String _resolvePath(String path, {required String from}) =>
     p.normalize(p.isAbsolute(path) ? path : p.join(from, path));
+
+String? _relativePathFromRepoRoot(String filePath, String repoRoot) {
+  if (_isInDirectory(filePath, repoRoot)) {
+    return p.relative(filePath, from: repoRoot);
+  }
+
+  final repoRootName = p.basename(repoRoot);
+  final filePathSegments = p.split(filePath);
+  final rootIndex = filePathSegments.lastIndexOf(repoRootName);
+  if (rootIndex == -1 || rootIndex == filePathSegments.length - 1) {
+    return null;
+  }
+
+  return p.joinAll(filePathSegments.skip(rootIndex + 1));
+}
 
 bool _isInDirectory(String path, String directory) =>
     path == directory || p.isWithin(directory, path);

--- a/packages/daco/test/file_utils_test.dart
+++ b/packages/daco/test/file_utils_test.dart
@@ -39,6 +39,39 @@ void main() {
       expect(result.map((f) => f.path), [kept.path]);
     });
 
+    test(
+      'filters ignored files below symlinked Flutter plugin directories',
+      () async {
+        await Process.run('git', ['init'], workingDirectory: tempDir.path);
+
+        final gitignore = File('${tempDir.path}/.gitignore');
+        await gitignore.writeAsString('linux/flutter/ephemeral/\n');
+
+        final pluginDir = Directory('${tempDir.path}/plugin');
+        await pluginDir.create();
+        final pluginFile = File('${pluginDir.path}/plugin.dart');
+        await pluginFile.writeAsString('');
+
+        final symlink = Link(
+          '${tempDir.path}/linux/flutter/ephemeral/.plugin_symlinks/plugin',
+        );
+        await symlink.parent.create(recursive: true);
+        await symlink.create(pluginDir.path);
+
+        final ignored = File('${symlink.path}/plugin.dart');
+        final kept = File('${tempDir.path}/lib/main.dart');
+        await kept.parent.create(recursive: true);
+        await kept.writeAsString('');
+
+        final result = await filterGitIgnoredFiles([
+          ignored,
+          kept,
+        ], workingDirectory: tempDir.path);
+
+        expect(result.map((f) => f.path), [kept.path]);
+      },
+    );
+
     test('returns all files when not in a git repo', () async {
       final file = File('${tempDir.path}/test.dart');
       await file.writeAsString('');

--- a/packages/daco/test/file_utils_test.dart
+++ b/packages/daco/test/file_utils_test.dart
@@ -39,6 +39,31 @@ void main() {
       expect(result.map((f) => f.path), [kept.path]);
     });
 
+    test('filters gitignored files with "." as working directory', () async {
+      final previousCurrent = Directory.current;
+      Directory.current = tempDir;
+      addTearDown(() => Directory.current = previousCurrent);
+
+      await Process.run('git', ['init'], workingDirectory: tempDir.path);
+
+      final gitignore = File('${tempDir.path}/.gitignore');
+      await gitignore.writeAsString('ignored/\n');
+
+      final kept = File('${tempDir.path}/kept.dart');
+      await kept.writeAsString('');
+      final ignoredDir = Directory('${tempDir.path}/ignored');
+      await ignoredDir.create();
+      final ignored = File('${tempDir.path}/ignored/file.dart');
+      await ignored.writeAsString('');
+
+      final result = await filterGitIgnoredFiles([
+        kept,
+        ignored,
+      ], workingDirectory: '.');
+
+      expect(result.map((f) => f.path), [kept.path]);
+    });
+
     test(
       'filters ignored files below symlinked Flutter plugin directories',
       () async {


### PR DESCRIPTION
## Summary
- update gitignored file filtering to resolve repository-relative paths before calling `git check-ignore`
- stop checking deeper path segments once a symlink is encountered so ignored Flutter ephemeral plugin paths are filtered correctly
- add a regression test covering symlinked Flutter plugin directories under ignored ephemeral folders

## Testing
- `dart test test/file_utils_test.dart`
- `dart analyze lib/src/file_utils.dart test/file_utils_test.dart`